### PR TITLE
Added special syntax to specify id and classes,

### DIFF
--- a/src/html-maker.coffee
+++ b/src/html-maker.coffee
@@ -160,7 +160,14 @@ class Maker
     @rawText string
 
   extractOptions: (args) ->
-    options = {}
+    options = {attributes:{}}
+    if typeof(args[0]) is 'string'
+      for item in args.shift().split(/(?=[#\.])/)
+        switch item[0]
+          when '#'
+            options.attributes.id = item.slice(1)
+          when '.'
+            options.attributes.class = (options.attributes.class || '') + " #{item.slice(1)}"
     for arg in args
       switch typeof(arg)
         when 'function'
@@ -168,7 +175,10 @@ class Maker
         when 'string', 'number'
           options.text = arg.toString()
         else
-          options.attributes = arg
+          options.attributes[k] = v for k,v of arg
     options
-
-module.exports = Maker
+  
+if typeof module?.exports is 'undefined'
+  @HtmlMaker = Maker
+else
+  module.exports = Maker


### PR DESCRIPTION
Mimicking haml syntax of #id.class1.class2.class3,
now you can do in html-maker:

@div '#button_one.btn.btn-primary.active', data: {toggle: 'collapse'}

which is similar to:

@div class: 'btn btn-primary active', id: 'button_one', data: {toggle: 'collapse'}

Take care: class and id specified as options (class: 'asdf', id: 'the_id')
would override '#the_id2.asdf2' special syntax. TODO: merge .class like in HAML ?